### PR TITLE
Handle limit attempt count

### DIFF
--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -1,6 +1,5 @@
 package com.rnfingerprint;
 
-import android.app.Dialog;
 import android.app.DialogFragment;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -12,9 +11,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.view.Window;
 
 import com.facebook.react.bridge.ReadableMap;
 
@@ -29,12 +26,13 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
     private int dialogColor = 0;
     private String dialogTitle = "";
     private int dialogTitleSize = 20;
+    private int limitAttempt = 3;
 
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
 
-        this.mFingerprintHandler = new FingerprintHandler(context, this);
+        this.mFingerprintHandler = new FingerprintHandler(context, this, limitAttempt);
     }
 
     @Override
@@ -133,6 +131,10 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
 
         if (config.hasKey("titleSize")) {
             this.dialogTitleSize = config.getInt("titleSize");
+        }
+
+        if (config.hasKey("limitAttempt")) {
+            this.limitAttempt = config.getInt("limitAttempt");
         }
     }
 

--- a/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
@@ -14,10 +14,13 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
 
     private final FingerprintManager mFingerprintManager;
     private final Callback mCallback;
+    private int attemptCount = 1;
+    private final int limitAttemt;
 
-    public FingerprintHandler(Context context, Callback callback) {
+    public FingerprintHandler(Context context, Callback callback, int limitAttemt) {
         mFingerprintManager = context.getSystemService(FingerprintManager.class);
         mCallback = callback;
+        this.limitAttemt = limitAttemt;
     }
 
     public void startAuth(FingerprintManager.CryptoObject cryptoObject) {
@@ -40,8 +43,12 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
 
     @Override
     public void onAuthenticationFailed() {
-        mCallback.onError("failed");
-        cancelAuthenticationSignal();
+        if (attemptCount < limitAttemt) {
+            attemptCount++;
+        } else {
+            mCallback.onError("failed");
+            cancelAuthenticationSignal();
+        }
     }
 
     @Override


### PR DESCRIPTION
# Summary
Currently, when user input fingerprint failed, the dialog will be dismissed, we do not want to handle it on React Native, so we will do it on native with `limitAttempt` configuration.