### PR TITLE
Chore: Fix Null Pointer Exception when calling onCancelled

### DIFF
--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -164,7 +164,9 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
     public void onCancelled() {
         this.isAuthInProgress = false;
         this.mFingerprintHandler.endAuth();
-        this.dialogCallback.onCancelled();
+        if (this.dialogCallback != null) {
+            this.dialogCallback.onCancelled();
+        }
         dismiss();
     }
 }


### PR DESCRIPTION
# Issue
https://sentry.io/organizations/employment-hero/issues/911674754/?environment=production&project=115026&query=is%3Aunresolved&statsPeriod=14d

If `dialogCallback` is null, the `onCancelled` can not be invoked, this PR adds the check to make sure the callback is called when `dialogCallback` has value