### PR TITLE
"Check null when call onAuthenticated,onError"

### DIFF
--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -149,14 +149,19 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
     @Override
     public void onAuthenticated() {
         this.isAuthInProgress = false;
-        this.dialogCallback.onAuthenticated();
+        if (this.dialogCallback != null) {
+          this.dialogCallback.onAuthenticated();
+        }
         dismiss();
     }
 
     @Override
     public void onError(String errorString) {
         this.isAuthInProgress = false;
-        this.dialogCallback.onError(errorString);
+        
+        if (this.dialogCallback != null) {
+          this.dialogCallback.onError(errorString);
+        }
         dismiss();
     }
 


### PR DESCRIPTION
Fix issue: https://sentry.io/organizations/employment-hero/issues/911674754/?project=115026&query=is%3Aunresolved&statsPeriod=24h

If dialogCallback is null, the onAuthenticated,onError  can not be invoked, this PR adds the check to make sure the callbacks are called when dialogCallback has value