### PR TITLE
Fix: Handle NPE error when startAuth

### DIFF
--- a/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintDialog.java
@@ -170,7 +170,7 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
         if (this.dialogCallback != null) {
           this.dialogCallback.onAuthenticated();
         }
-        dismiss();
+        dismissAllowingStateLoss();
     }
 
     @Override
@@ -187,6 +187,6 @@ public class FingerprintDialog extends DialogFragment implements FingerprintHand
         if (this.dialogCallback != null) {
             this.dialogCallback.onCancelled();
         }
-        dismiss();
+        dismissAllowingStateLoss();
     }
 }

--- a/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
+++ b/android/src/main/java/com/rnfingerprint/FingerprintHandler.java
@@ -23,7 +23,12 @@ public class FingerprintHandler extends FingerprintManager.AuthenticationCallbac
     public void startAuth(FingerprintManager.CryptoObject cryptoObject) {
         cancellationSignal = new CancellationSignal();
         selfCancelled = false;
-        mFingerprintManager.authenticate(cryptoObject, cancellationSignal, 0, this, null);
+        try {
+            mFingerprintManager.authenticate(cryptoObject, cancellationSignal, 0, this, null);
+        } catch (NullPointerException exception) {
+            mCallback.onCancelled();
+        }
+
     }
 
     public void endAuth() {


### PR DESCRIPTION
# Summary
Sometime when users stop and resume the application , while the fingerprint authentication is active, `FingerprintManager.startAuth` method raises NPE.
![image](https://user-images.githubusercontent.com/40555128/111731409-fff28f80-88a5-11eb-9d41-e6bf41e3b283.png)

To avoid this issue, I add a workaround to cancel biometric authentication when `FingerprintManager` raise this issue. The mobile falls back to passcode input

Related issue: https://github.com/wultra/powerauth-mobile-sdk/issues/202